### PR TITLE
Fixes relative require break

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var transformTools = require('browserify-transform-tools');
 var resolve = require('resolve');
+var path = require('path')
 
 var transform = transformTools.makeRequireTransform(
     "resolvify",
@@ -15,7 +16,7 @@ var transform = transformTools.makeRequireTransform(
                         },[])
         if (paths.length == 0) { return cb(null) }
         resolved = resolve.sync(args[0], {
-            basedir: __dirname,
+            basedir: path.dirname(opts.file),
             moduleDirectory: ['node_modules'].concat(paths)
         });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resolvify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Resolve directories as well as their ancestors like \"node_modules\"",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
Yeah, your way was better than my way :stuck_out_tongue_closed_eyes: Since we are changing resolve for all module, using the base <code>__dirname</code> make relative imports break. So yeah, hehe...

Anyway, fixed here and bumped version number :+1: 
