### PR TITLE
Fix CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ resolvify: ["shared"]
 ...
 ```
 ```
-browserify [ -t resolvify common ]
+browserify -t [ resolvify common ]
 ```
 
 Then both the folders "shared" and "common" will be resolved like "node_modules".


### PR DESCRIPTION
The command at the end of the readme doesn't work. It seems that the correct syntax is with the `-t` on the outside, as shown in the browserify readme: 

> Passing arguments to transforms and plugins:
> 
>   For -t, -g, and -p, you may use subarg syntax to pass options to the
>   transforms or plugin function as the second parameter. For example:
> 
>    `-t [ foo -x 3 --beep ]`

After I changed the command to this syntax it fixed the error.
